### PR TITLE
feat: Enable  wildcard CORS support

### DIFF
--- a/backend/docs/CORS_CONFIGURATION.md
+++ b/backend/docs/CORS_CONFIGURATION.md
@@ -1,0 +1,228 @@
+# CORS Configuration
+
+## Overview
+
+The ChartImpact backend implements Cross-Origin Resource Sharing (CORS) middleware with support for wildcard patterns, enabling flexible configuration for multiple deployment environments including Cloudflare Pages preview deployments.
+
+## Configuration
+
+CORS is configured via environment variables:
+
+### Environment Variables
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `CORS_ALLOWED_ORIGINS` | Comma-separated list of allowed origins. Supports wildcards (`*`). | `http://localhost:3000,http://localhost:3001` | `https://app.example.com,https://*.preview.pages.dev` |
+| `CORS_ALLOWED_METHODS` | Comma-separated list of allowed HTTP methods | `GET,POST,PUT,DELETE,OPTIONS` | `GET,POST` |
+| `CORS_ALLOWED_HEADERS` | Comma-separated list of allowed request headers | `Content-Type,Authorization` | `Content-Type,X-Custom-Header` |
+
+### Wildcard Pattern Support
+
+The CORS middleware supports wildcard patterns using asterisk (`*`) to match dynamic subdomains or prefixes:
+
+#### Examples
+
+**Subdomain wildcards:**
+```bash
+CORS_ALLOWED_ORIGINS="https://*.example.com"
+```
+Matches:
+- ✅ `https://app.example.com`
+- ✅ `https://staging.example.com`
+- ✅ `https://preview-123.example.com`
+- ❌ `https://example.com` (no subdomain)
+- ❌ `https://malicious.different.com`
+
+**Prefix wildcards:**
+```bash
+CORS_ALLOWED_ORIGINS="https://preview-*.pages.dev"
+```
+Matches:
+- ✅ `https://preview-abc123.pages.dev`
+- ✅ `https://preview-feature-xyz.pages.dev`
+- ❌ `https://other-abc123.pages.dev`
+
+**Multiple patterns:**
+```bash
+CORS_ALLOWED_ORIGINS="https://app.example.com,https://*.preview.pages.dev,http://localhost:3000"
+```
+Matches:
+- ✅ `https://app.example.com` (exact match)
+- ✅ `https://feature-123.preview.pages.dev` (wildcard match)
+- ✅ `http://localhost:3000` (exact match)
+
+## Cloudflare Pages Configuration
+
+For Cloudflare Pages deployments with preview environments:
+
+### Production + Preview Deployments
+
+```bash
+CORS_ALLOWED_ORIGINS="https://ci.dcotelo.dev,https://*.chartimpact.pages.dev,http://localhost:3000"
+```
+
+This configuration allows:
+- Production domain: `https://ci.dcotelo.dev`
+- All preview deployments: `https://*.chartimpact.pages.dev`
+  - Hash-based previews: `https://da5dc162.chartimpact.pages.dev`
+  - Branch-based previews: `https://feat-new-feature.chartimpact.pages.dev`
+- Local development: `http://localhost:3000`
+
+### fly.toml Configuration
+
+In your `fly.toml` file:
+
+```toml
+[env]
+  CORS_ALLOWED_ORIGINS = "https://ci.dcotelo.dev,https://*.chartimpact.pages.dev,http://localhost:3000"
+  CORS_ALLOWED_METHODS = "GET,POST,PUT,DELETE,OPTIONS"
+  CORS_ALLOWED_HEADERS = "Content-Type,Authorization"
+```
+
+## Implementation Details
+
+### Pattern Matching Algorithm
+
+1. **Exact Match**: If the allowed origin doesn't contain `*`, exact string comparison is performed
+2. **Wildcard Match**: If the allowed origin contains `*`:
+   - Special regex characters are escaped using `regexp.QuoteMeta()`
+   - `*` is replaced with `.*` (regex for "any character, any times")
+   - Full regex match is performed: `^pattern$`
+
+### Security Considerations
+
+**✅ Safe Patterns:**
+```bash
+https://*.trusted-domain.com
+https://preview-*.pages.dev
+```
+
+**⚠️ Use with Caution:**
+```bash
+https://*  # Allows any HTTPS origin
+*          # Allows any origin (very insecure)
+```
+
+**Best Practices:**
+- Always include the domain after the wildcard
+- Use wildcards only for trusted domains you control
+- Test your patterns thoroughly
+- Monitor CORS errors in production logs
+
+### CORS Preflight Requests
+
+The middleware automatically handles OPTIONS preflight requests:
+- Returns `204 No Content` status
+- Sets all required CORS headers
+- Does not forward the request to downstream handlers
+
+### Request Flow
+
+1. Browser sends request with `Origin` header
+2. Middleware checks if origin matches any allowed pattern
+3. If matched:
+   - Sets `Access-Control-Allow-Origin: <origin>`
+   - Sets other CORS headers
+   - Proceeds to handler
+4. If not matched:
+   - No CORS headers set
+   - Browser blocks the request
+
+## Testing
+
+Comprehensive test suite available in `middleware_test.go`:
+
+```bash
+# Run CORS tests
+go test ./internal/api/middleware -v
+
+# Run specific test
+go test ./internal/api/middleware -v -run TestCORS_WildcardPattern
+
+# Run with coverage
+go test ./internal/api/middleware -cover
+```
+
+### Test Coverage
+
+- ✅ Exact origin matching
+- ✅ Wildcard subdomain patterns
+- ✅ Wildcard prefix patterns
+- ✅ Multiple allowed origins
+- ✅ Preflight OPTIONS requests
+- ✅ Custom headers and methods
+- ✅ Cloudflare Pages deployment patterns
+- ✅ Disallowed origins
+
+## Troubleshooting
+
+### Common Issues
+
+**Issue**: CORS error despite correct configuration
+```
+Access-Control-Allow-Origin header has a value that is not equal to the supplied origin
+```
+
+**Solutions:**
+1. Verify environment variable is set: `fly secrets list`
+2. Check for trailing slashes in URLs
+3. Ensure HTTPS/HTTP scheme matches exactly
+4. Redeploy after changing environment variables
+5. Check browser console for actual origin being sent
+
+**Issue**: Wildcard pattern not matching
+
+**Solutions:**
+1. Test pattern with the test suite
+2. Verify no typos in pattern
+3. Remember wildcards must match at least one character
+4. Check if scheme (http/https) matches
+
+**Issue**: Preflight request failing
+
+**Solutions:**
+1. Ensure server responds to OPTIONS requests
+2. Verify all CORS headers are set
+3. Check if origin is in allowed list
+4. Look for server-side redirects (not allowed in preflight)
+
+## Deployment Checklist
+
+Before deploying:
+
+- [ ] Set `CORS_ALLOWED_ORIGINS` in `fly.toml` or via secrets
+- [ ] Include production domain(s)
+- [ ] Add wildcard pattern for preview deployments
+- [ ] Keep `localhost` for local development
+- [ ] Test with actual preview deployment URLs
+- [ ] Verify preflight requests work
+- [ ] Check browser console for CORS errors
+- [ ] Monitor production logs
+
+## Examples
+
+### Local Development
+```bash
+CORS_ALLOWED_ORIGINS="http://localhost:3000,http://localhost:3001"
+```
+
+### Single Production Domain
+```bash
+CORS_ALLOWED_ORIGINS="https://app.example.com"
+```
+
+### Production + Staging
+```bash
+CORS_ALLOWED_ORIGINS="https://app.example.com,https://staging.example.com"
+```
+
+### Full Stack (Recommended)
+```bash
+CORS_ALLOWED_ORIGINS="https://app.example.com,https://*.preview.pages.dev,http://localhost:3000"
+```
+
+## References
+
+- [MDN Web Docs: CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
+- [Cloudflare Pages Documentation](https://developers.cloudflare.com/pages/)
+- [Go regexp package](https://pkg.go.dev/regexp)

--- a/backend/internal/api/middleware/middleware_test.go
+++ b/backend/internal/api/middleware/middleware_test.go
@@ -1,10 +1,269 @@
 package middleware
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
 )
 
-// Basic test placeholder - middleware is tested via integration tests
-func TestMiddlewarePackage(t *testing.T) {
-	t.Log("Middleware package compiles successfully")
+// mockHandler is a simple handler for testing middleware
+var mockHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
+})
+
+func TestCORS_ExactMatch(t *testing.T) {
+	// Set up environment
+	os.Setenv("CORS_ALLOWED_ORIGINS", "https://example.com,https://app.example.com")
+	defer os.Unsetenv("CORS_ALLOWED_ORIGINS")
+
+	tests := []struct {
+		name           string
+		origin         string
+		expectedOrigin string
+		shoudAllow     bool
+	}{
+		{
+			name:           "allowed origin - exact match",
+			origin:         "https://example.com",
+			expectedOrigin: "https://example.com",
+			shoudAllow:     true,
+		},
+		{
+			name:           "allowed origin - second in list",
+			origin:         "https://app.example.com",
+			expectedOrigin: "https://app.example.com",
+			shoudAllow:     true,
+		},
+		{
+			name:           "disallowed origin",
+			origin:         "https://malicious.com",
+			expectedOrigin: "",
+			shoudAllow:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/api/test", nil)
+			req.Header.Set("Origin", tt.origin)
+			w := httptest.NewRecorder()
+
+			handler := CORS(mockHandler)
+			handler.ServeHTTP(w, req)
+
+			gotOrigin := w.Header().Get("Access-Control-Allow-Origin")
+			if tt.shoudAllow {
+				if gotOrigin != tt.expectedOrigin {
+					t.Errorf("Expected origin %q, got %q", tt.expectedOrigin, gotOrigin)
+				}
+			} else {
+				if gotOrigin != "" {
+					t.Errorf("Expected no CORS header for disallowed origin, got %q", gotOrigin)
+				}
+			}
+		})
+	}
+}
+
+func TestCORS_WildcardPattern(t *testing.T) {
+	// Set up environment with wildcard patterns
+	os.Setenv("CORS_ALLOWED_ORIGINS", "https://*.example.com,https://preview-*.pages.dev,http://localhost:3000")
+	defer os.Unsetenv("CORS_ALLOWED_ORIGINS")
+
+	tests := []struct {
+		name           string
+		origin         string
+		expectedOrigin string
+		shouldAllow    bool
+	}{
+		{
+			name:           "wildcard subdomain match",
+			origin:         "https://app.example.com",
+			expectedOrigin: "https://app.example.com",
+			shouldAllow:    true,
+		},
+		{
+			name:           "wildcard subdomain - another match",
+			origin:         "https://staging.example.com",
+			expectedOrigin: "https://staging.example.com",
+			shouldAllow:    true,
+		},
+		{
+			name:           "wildcard prefix match",
+			origin:         "https://preview-abc123.pages.dev",
+			expectedOrigin: "https://preview-abc123.pages.dev",
+			shouldAllow:    true,
+		},
+		{
+			name:           "wildcard prefix - another match",
+			origin:         "https://preview-xyz789.pages.dev",
+			expectedOrigin: "https://preview-xyz789.pages.dev",
+			shouldAllow:    true,
+		},
+		{
+			name:           "exact match still works",
+			origin:         "http://localhost:3000",
+			expectedOrigin: "http://localhost:3000",
+			shouldAllow:    true,
+		},
+		{
+			name:           "wildcard doesn't match different domain",
+			origin:         "https://app.different.com",
+			expectedOrigin: "",
+			shouldAllow:    false,
+		},
+		{
+			name:           "wildcard doesn't match partial domain",
+			origin:         "https://example.com",
+			expectedOrigin: "",
+			shouldAllow:    false,
+		},
+		{
+			name:           "malicious origin blocked",
+			origin:         "https://malicious.com",
+			expectedOrigin: "",
+			shouldAllow:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/api/test", nil)
+			req.Header.Set("Origin", tt.origin)
+			w := httptest.NewRecorder()
+
+			handler := CORS(mockHandler)
+			handler.ServeHTTP(w, req)
+
+			gotOrigin := w.Header().Get("Access-Control-Allow-Origin")
+			if tt.shouldAllow {
+				if gotOrigin != tt.expectedOrigin {
+					t.Errorf("Expected origin %q, got %q", tt.expectedOrigin, gotOrigin)
+				}
+			} else {
+				if gotOrigin != "" {
+					t.Errorf("Expected no CORS header for disallowed origin, got %q", gotOrigin)
+				}
+			}
+
+			// Verify other CORS headers are set
+			if w.Header().Get("Access-Control-Allow-Methods") == "" {
+				t.Error("Expected Access-Control-Allow-Methods header to be set")
+			}
+			if w.Header().Get("Access-Control-Allow-Headers") == "" {
+				t.Error("Expected Access-Control-Allow-Headers header to be set")
+			}
+			if w.Header().Get("Access-Control-Allow-Credentials") != "true" {
+				t.Error("Expected Access-Control-Allow-Credentials to be 'true'")
+			}
+		})
+	}
+}
+
+func TestCORS_PreflightRequest(t *testing.T) {
+	os.Setenv("CORS_ALLOWED_ORIGINS", "https://example.com")
+	defer os.Unsetenv("CORS_ALLOWED_ORIGINS")
+
+	req := httptest.NewRequest("OPTIONS", "/api/test", nil)
+	req.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+
+	handler := CORS(mockHandler)
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected status %d for preflight request, got %d", http.StatusNoContent, w.Code)
+	}
+
+	if w.Header().Get("Access-Control-Allow-Origin") != "https://example.com" {
+		t.Error("Expected CORS headers to be set for preflight request")
+	}
+}
+
+func TestCORS_CustomConfiguration(t *testing.T) {
+	os.Setenv("CORS_ALLOWED_ORIGINS", "https://custom.com")
+	os.Setenv("CORS_ALLOWED_METHODS", "GET,POST")
+	os.Setenv("CORS_ALLOWED_HEADERS", "X-Custom-Header")
+	defer func() {
+		os.Unsetenv("CORS_ALLOWED_ORIGINS")
+		os.Unsetenv("CORS_ALLOWED_METHODS")
+		os.Unsetenv("CORS_ALLOWED_HEADERS")
+	}()
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set("Origin", "https://custom.com")
+	w := httptest.NewRecorder()
+
+	handler := CORS(mockHandler)
+	handler.ServeHTTP(w, req)
+
+	if w.Header().Get("Access-Control-Allow-Methods") != "GET,POST" {
+		t.Errorf("Expected custom methods, got %q", w.Header().Get("Access-Control-Allow-Methods"))
+	}
+
+	if w.Header().Get("Access-Control-Allow-Headers") != "X-Custom-Header" {
+		t.Errorf("Expected custom headers, got %q", w.Header().Get("Access-Control-Allow-Headers"))
+	}
+}
+
+func TestCORS_CloudflarePagesPattern(t *testing.T) {
+	// Real-world test for Cloudflare Pages preview deployments
+	os.Setenv("CORS_ALLOWED_ORIGINS", "https://ci.dcotelo.dev,https://*.chartimpact.pages.dev,http://localhost:3000")
+	defer os.Unsetenv("CORS_ALLOWED_ORIGINS")
+
+	tests := []struct {
+		name        string
+		origin      string
+		shouldAllow bool
+	}{
+		{
+			name:        "production domain",
+			origin:      "https://ci.dcotelo.dev",
+			shouldAllow: true,
+		},
+		{
+			name:        "preview deployment with hash",
+			origin:      "https://da5dc162.chartimpact.pages.dev",
+			shouldAllow: true,
+		},
+		{
+			name:        "preview deployment with name",
+			origin:      "https://copilot-codebase-review-and.chartimpact.pages.dev",
+			shouldAllow: true,
+		},
+		{
+			name:        "localhost development",
+			origin:      "http://localhost:3000",
+			shouldAllow: true,
+		},
+		{
+			name:        "different pages.dev domain blocked",
+			origin:      "https://malicious.other.pages.dev",
+			shouldAllow: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/api/versions", nil)
+			req.Header.Set("Origin", tt.origin)
+			w := httptest.NewRecorder()
+
+			handler := CORS(mockHandler)
+			handler.ServeHTTP(w, req)
+
+			gotOrigin := w.Header().Get("Access-Control-Allow-Origin")
+			if tt.shouldAllow {
+				if gotOrigin != tt.origin {
+					t.Errorf("Expected origin %q to be allowed, got %q", tt.origin, gotOrigin)
+				}
+			} else {
+				if gotOrigin != "" {
+					t.Errorf("Expected origin %q to be blocked, but got %q", tt.origin, gotOrigin)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
This pull request introduces comprehensive improvements to the backend's CORS (Cross-Origin Resource Sharing) middleware, adding robust wildcard pattern support for allowed origins, updating documentation, and significantly expanding test coverage. These changes enable flexible and secure CORS configuration for multiple deployment environments, including dynamic preview URLs (e.g., Cloudflare Pages), and ensure that only explicitly allowed origins receive CORS headers.

**CORS Middleware Enhancements**

* Added support for wildcard patterns (e.g., `https://*.example.com`, `https://preview-*.pages.dev`) in the `CORS_ALLOWED_ORIGINS` environment variable, allowing dynamic origin matching using regex-based pattern conversion. [[1]](diffhunk://#diff-a64180594664d2ac99b069ce1da8216d87d951d01c8230e12acc356fa0949327R6-R23) [[2]](diffhunk://#diff-a64180594664d2ac99b069ce1da8216d87d951d01c8230e12acc356fa0949327R33-R50)
* Updated the CORS middleware to only set CORS headers if the request's origin matches an allowed pattern; previously, the first allowed origin was used as a fallback, which could be unsafe.

**Documentation Updates**

* Added a detailed `CORS_CONFIGURATION.md` file documenting environment variables, wildcard pattern usage, security considerations, Cloudflare Pages deployment examples, troubleshooting, and deployment best practices.
* Improved inline documentation in `cors.go` to clarify the new wildcard support and pattern matching logic.

**Testing Improvements**

* Replaced the placeholder middleware test with a comprehensive test suite in `middleware_test.go`, covering:
  - Exact origin matching
  - Wildcard subdomain and prefix patterns
  - Multiple allowed origins
  - Preflight (OPTIONS) requests
  - Custom headers and methods
  - Real-world Cloudflare Pages deployment scenarios
  - Negative cases (disallowed and malicious origins)

These changes provide a more flexible, secure, and well-documented CORS implementation suitable for modern frontend-backend deployments.