### PR TITLE
fix: Release process

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -5,14 +5,7 @@
       "package-name": "chartimpact-backend",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
-      "extra-files": [
-        {
-          "type": "json",
-          "path": "../frontend/package.json",
-          "jsonpath": "$.version"
-        }
-      ]
+      "bump-patch-for-minor-pre-major": true
     },
     "frontend": {
       "release-type": "node",


### PR DESCRIPTION
This pull request makes a small adjustment to the release configuration. The change removes the automatic updating of the `version` field in the `../frontend/package.json` file during backend releases. No other changes are included.

- Removed the `extra-files` configuration that updated `../frontend/package.json`'s version as part of the backend release process in `.github/release-please-config.json`.