### PR TITLE
fix: update release configuration to include component in tag

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -3,6 +3,7 @@
     ".": {
       "release-type": "simple",
       "package-name": "chartimpact",
+      "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
This pull request makes a minor configuration update to the release process. The change disables including the component name in the release tag for the `chartimpact` package.

- [`.github/release-please-config.json`](diffhunk://#diff-b4c6ab25197e992b430b71d65743b6459f06f248f7c6b3364f1942e40d9f0039R6): Set `include-component-in-tag` to `false` to simplify release tag naming.