### PR TITLE
chore: update Fly.io configuration to optimize VM resources

### DIFF
--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -17,10 +17,8 @@ primary_region = 'gru'
   processes = ['app']
 
 [[vm]]
-  memory = '1gb'
-  cpu_kind = 'shared'
-  cpus = 1
-  memory_mb = 1024
+  size = "shared-cpu-1x"
+  memory = "256mb"
 [env]
   CORS_ALLOWED_ORIGINS="https://ci.dcotelo.dev,https://*.chartimpact.pages.dev,http://localhost:3000"
   CORS_ALLOWED_METHODS="GET,POST,PUT,DELETE,OPTIONS"


### PR DESCRIPTION
This pull request updates the VM configuration in the `backend/fly.toml` file to reduce resource usage and simplify the configuration by using a preset VM size.

Resource allocation updates:

* Changed the VM configuration from specifying individual resources (`memory`, `cpu_kind`, `cpus`, `memory_mb`) to using the `size = "shared-cpu-1x"` preset and reduced memory allocation to `"256mb"`.